### PR TITLE
Fixed setup.py installation error when building on os x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     package_data = {
         'mediasync': [
-            'tests/media/*',
+            'tests/media/*/*',
         ]
     },
     license='BSD License',


### PR DESCRIPTION
I kept getting an installation error on os X with the saying that the css and js files couldn't be moved since they weren't normal files. I just expanded the wildcard search to go down another level and it built and installed fine.
