### PR TITLE
Minor addition to JS mimetypes

### DIFF
--- a/mediasync/__init__.py
+++ b/mediasync/__init__.py
@@ -7,6 +7,7 @@ import os
 
 JS_MIMETYPES = (
     "application/javascript",
+    "application/x-javascript",
     "text/javascript", # obsolete, see RFC 4329
 )
 CSS_MIMETYPES = (


### PR DESCRIPTION
I added application/x-javascript as a JS mimetype, as our servers default JS files to that, so gizpping was failing. If you can merge this into your branch, that'd be great.

Thanks
