### PR TITLE
only run the closure compiler when it is active

### DIFF
--- a/mediasync/processors/closurecompiler.py
+++ b/mediasync/processors/closurecompiler.py
@@ -5,11 +5,11 @@ import httplib
 HEADERS = {"content-type": "application/x-www-form-urlencoded"}
 
 def compile(filedata, content_type, remote_path, is_active):
-    
+
     is_js = (content_type in JS_MIMETYPES or remote_path.lower().endswith('.js'))
-    
-    if is_js:
-        
+
+    if is_active and is_js:
+
         params = urlencode({
             'js_code': filedata,
             'compilation_level': 'SIMPLE_OPTIMIZATIONS',
@@ -22,5 +22,5 @@ def compile(filedata, content_type, remote_path, is_active):
         response = conn.getresponse()
         data = response.read()
         conn.close
-        
+
         return data


### PR DESCRIPTION
Currently the closure compiler runs all the time, even when inactive. This fixes that.
