### PR TITLE
Fix minor bug in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Serving media remote (S3/Cloud Files) or locally
 ------------------------------------------------
 
 The media URL is selected based on the *SERVE_REMOTE* attribute in the
-*MEDIASYNC* dict in settings.py. When *True*, media will be served locally 
+*MEDIASYNC* dict in settings.py. When *False*, media will be served locally 
 instead of from S3.
 
 ::


### PR DESCRIPTION
The README currently states that django-mediasync will serve locally if `SERVE_REMOTE` is `True`. Which is the opposite of what it should say.
