### PR TITLE
Django 1.5 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,7 +607,13 @@ and direct the user to the appropriate file based on the ACCEPT_ENCODING HTTP
 header. Assuming a file styles/layout.css, the following would be synced to S3::
 
 	styles/layout.css
-	styles/layout.css.gz
+	styles/layout.css.gzt
+
+Note the altered use of the .gz extension. Some versions of the Safari browser
+on OSX ignore the Content-Type header for files ending in .gz and treat them
+instead as files to download. This altered extension allows Safari to deflate
+and utilize the files correctly without affecting functionality in any other
+tested browsers.
 
 Signals
 =======

--- a/mediasync/__init__.py
+++ b/mediasync/__init__.py
@@ -174,4 +174,4 @@ def sync(client=None, force=False, verbose=True):
 
 
 __all__ = ['sync', 'SyncException']
-__version__ = '2.2.0'
+__version__ = '2.2.1'

--- a/mediasync/backends/s3.py
+++ b/mediasync/backends/s3.py
@@ -90,12 +90,12 @@ class Client(BaseClient):
             # check to see if file should be gzipped based on content_type
             # also check to see if filesize is greater than 1kb
             if content_type in TYPES_TO_COMPRESS:
-                
-                key = Key(self._bucket, "%s.gz" % remote_path)
+                # Use a .gzt extension to avoid issues with Safari on OSX
+                key = Key(self._bucket, "%s.gzt" % remote_path)
                 
                 filedata = mediasync.compress(filedata)
                 (hexdigest, b64digest) = mediasync.checksum(filedata) # update checksum with compressed data
-                headers["Content-Disposition"] = 'inline; filename="%sgz"' % remote_path.split('/')[-1]
+                headers["Content-Disposition"] = 'inline; filename="%sgzt"' % remote_path.split('/')[-1]
                 headers["Content-Encoding"] = 'gzip'
                 
                 key.set_metadata('mediasync-checksum', raw_b64digest)

--- a/mediasync/templatetags/media.py
+++ b/mediasync/templatetags/media.py
@@ -63,7 +63,7 @@ class BaseTagNode(template.Node):
           path: (str) The path on the host (specified in 'url') leading up
                       to the file.
           filename: (str) The file name to serve.
-          gzip: (bool) True if client should receive *.gz version of file.
+          gzip: (bool) True if client should receive *.gzt version of file.
         """
         if path:
             url = "%s/%s" % (url.rstrip('/'), path.strip('/'))
@@ -73,7 +73,7 @@ class BaseTagNode(template.Node):
         
         content_type = mimetypes.guess_type(url)[0]
         if gzip and content_type in mediasync.TYPES_TO_COMPRESS:
-            url = "%s.gz" % url
+            url = "%s.gzt" % url
 
         cb = msettings['CACHE_BUSTER']
         if cb:

--- a/mediasync/tests/tests.py
+++ b/mediasync/tests/tests.py
@@ -239,10 +239,10 @@ class S3ClientTestCase(unittest.TestCase):
             
             if content_type in mediasync.TYPES_TO_COMPRESS:
                 
-                key = bucket.get_key("%s.gz" % path)
+                key = bucket.get_key("%s.gzt" % path)
                 
                 # do a HEAD request on the file
-                http_conn.request('HEAD', "/%s/%s.gz" % (self.bucket_name, path))
+                http_conn.request('HEAD', "/%s/%s.gzt" % (self.bucket_name, path))
                 response = http_conn.getresponse()
                 response.read()
                 

--- a/mediasync/views.py
+++ b/mediasync/views.py
@@ -108,5 +108,9 @@ def static_serve(request, path, client):
     # Django static serve view.
     
     resp = serve(request, path, document_root=client.media_root, show_indexes=True)
-    resp.content = client.process(resp.content, resp['Content-Type'], path)
+    try:
+        resp.content = client.process(resp.content, resp['Content-Type'], path)
+    except KeyError:
+        # HTTPNotModifiedResponse lacks the "Content-Type" key.
+        pass
     return resp

--- a/mediasync/views.py
+++ b/mediasync/views.py
@@ -6,8 +6,8 @@ these are shimmed in.
 The static_serve() function is where the party starts.
 """
 from django.http import HttpResponse
+from django.shortcuts import redirect
 from django.views.static import serve
-from django.views.generic.simple import redirect_to
 from mediasync import combine_files
 from mediasync.conf import msettings
 
@@ -93,7 +93,7 @@ def static_serve(request, path, client):
     if msettings['SERVE_REMOTE']:
         # We're serving from S3, redirect there.
         url = client.remote_media_url().strip('/') + '/%(path)s'
-        return redirect_to(request, url, path=path)
+        return redirect(url, permanent=True)
 
     if not msettings['SERVE_REMOTE'] and msettings['EMULATE_COMBO']:
         # Combo emulation is on and we're serving media locally. Try to see if


### PR DESCRIPTION
This update addresses the use of an outdated function-based view (`django.views.generic.simple.redirect_to`) which causes an exception in Django 1.5.
