### PR TITLE
Update urls.py to fits  >= 1.5

### DIFF
--- a/mediasync/urls.py
+++ b/mediasync/urls.py
@@ -2,7 +2,7 @@
 Mediasync can serve media locally when MEDIASYNC['SERVE_REMOTE'] == False.
 The following urlpatterns are shimmed in, in that case.
 """
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from mediasync import backends
 
 client = backends.client()


### PR DESCRIPTION
"django.conf.urls.defaults" is deprecated on Django 1.5.x, and may be deleted on the next releases
I remplaced it by "django.conf.urls" 
